### PR TITLE
mt7530: fixed pending-6.6 723-net-mt7531-ensure-all-MACs-are-powered-…

### DIFF
--- a/target/linux/generic/pending-6.6/723-net-mt7531-ensure-all-MACs-are-powered-down-before-r.patch
+++ b/target/linux/generic/pending-6.6/723-net-mt7531-ensure-all-MACs-are-powered-down-before-r.patch
@@ -21,7 +21,7 @@ Signed-off-by: Alexander Couzens <lynxis@fe80.eu>
  
 +	/* all MACs must be forced link-down before sw reset */
 +	for (i = 0; i < MT7530_NUM_PORTS; i++)
-+		mt7530_write(priv, MT7530_PMCR_P(i), MT7531_FORCE_LNK);
++		mt7530_write(priv, MT753X_PMCR_P(i), MT7531_FORCE_MODE_LNK);
 +
  	/* Reset the switch through internal reset */
  	mt7530_write(priv, MT7530_SYS_CTRL,


### PR DESCRIPTION
…down-before-r.patch compilation error

rename MT7530_PMCR_P to MT753X_PMCR_P

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
